### PR TITLE
switched reservation method to running javascript we scrape from obtain method

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,4 @@ Simply change the kerebos credentials in `main.py` to your account info and then
 python main.py
 
 ```
+


### PR DESCRIPTION
This fixed a bug of `.click` method on html object being "stale" and not actually reserving timeslots. We scrape the javascript of reserving spots and save those for later instead of scraping html button path in DOM for clicking later. 